### PR TITLE
Feat: Support modify listening address

### DIFF
--- a/main.go
+++ b/main.go
@@ -176,7 +176,7 @@ func updateTgbotSetting(tgBotToken string, tgBotChatid int, tgBotRuntime string)
 	}
 }
 
-func updateSetting(port int, username string, password string) {
+func updateSetting(listen_addr string, port int, username string, password string) {
 	err := database.InitDB(config.GetDBPath())
 	if err != nil {
 		fmt.Println(err)
@@ -185,6 +185,14 @@ func updateSetting(port int, username string, password string) {
 
 	settingService := service.SettingService{}
 
+	if listen_addr != "" {
+		err := settingService.SetListen(listen_addr)
+		if err != nil {
+			fmt.Println("set listening address failed:", err)
+		} else {
+			fmt.Printf("set listening address %v success", listen_addr)
+		}
+	}
 	if port > 0 {
 		err := settingService.SetPort(port)
 		if err != nil {
@@ -220,6 +228,7 @@ func main() {
 	v2uiCmd.StringVar(&dbPath, "db", "/etc/v2-ui/v2-ui.db", "set v2-ui db file path")
 
 	settingCmd := flag.NewFlagSet("setting", flag.ExitOnError)
+	var listen_addr string
 	var port int
 	var username string
 	var password string
@@ -231,6 +240,7 @@ func main() {
 	var show bool
 	settingCmd.BoolVar(&reset, "reset", false, "reset all settings")
 	settingCmd.BoolVar(&show, "show", false, "show current settings")
+	settingCmd.StringVar(&listen_addr, "listen", "", "set listening address")
 	settingCmd.IntVar(&port, "port", 0, "set panel port")
 	settingCmd.StringVar(&username, "username", "", "set login username")
 	settingCmd.StringVar(&password, "password", "", "set login password")
@@ -282,7 +292,7 @@ func main() {
 		if reset {
 			resetSetting()
 		} else {
-			updateSetting(port, username, password)
+			updateSetting(listen_addr, port, username, password)
 		}
 		if show {
 			showSetting(show)

--- a/main.go
+++ b/main.go
@@ -95,6 +95,7 @@ func resetSetting() {
 func showSetting(show bool) {
 	if show {
 		settingService := service.SettingService{}
+		listen_addr, err := settingService.GetListen()
 		port, err := settingService.GetPort()
 		if err != nil {
 			fmt.Println("get current port fialed,error info:", err)
@@ -112,6 +113,7 @@ func showSetting(show bool) {
 		fmt.Println("current pannel settings as follows:")
 		fmt.Println("username:", username)
 		fmt.Println("userpasswd:", userpasswd)
+		fmt.Println("listen:", listen_addr)
 		fmt.Println("port:", port)
 	}
 }

--- a/web/service/setting.go
+++ b/web/service/setting.go
@@ -194,6 +194,10 @@ func (s *SettingService) GetListen() (string, error) {
 	return s.getString("webListen")
 }
 
+func (s *SettingService) SetListen(listen_addr string) error {
+	return s.setString("webListen", listen_addr)
+}
+
 func (s *SettingService) GetTgBotToken() (string, error) {
 	return s.getString("tgBotToken")
 }

--- a/x-ui.sh
+++ b/x-ui.sh
@@ -180,6 +180,18 @@ check_config() {
     LOGI "${info}"
 }
 
+set_listen() {
+    echo && echo -n -e "输入IPv4监听地址: " && read addr
+    if [[ -z "${addr}" ]]; then
+        LOGD "已取消"
+        before_show_menu
+    else
+        /usr/local/x-ui/x-ui setting -listen ${addr}
+        echo -e "设置监听地址完毕，现在请重启面板，并通过新设置的地址 ${green}${addr}${plain} 访问面板"
+        confirm_restart
+    fi
+}
+
 set_port() {
     echo && echo -n -e "输入端口号[1-65535]: " && read port
     if [[ -z "${port}" ]]; then
@@ -512,23 +524,24 @@ show_menu() {
 ————————————————
   ${green}4.${plain} 重置用户名密码
   ${green}5.${plain} 重置面板设置
-  ${green}6.${plain} 设置面板端口
-  ${green}7.${plain} 查看当前面板设置
+  ${green}6.${plain} 设置面板监听地址
+  ${green}7.${plain} 设置面板端口
+  ${green}8.${plain} 查看当前面板设置
 ————————————————
-  ${green}8.${plain} 启动 x-ui
-  ${green}9.${plain} 停止 x-ui
-  ${green}10.${plain} 重启 x-ui
-  ${green}11.${plain} 查看 x-ui 状态
-  ${green}12.${plain} 查看 x-ui 日志
+  ${green}9.${plain} 启动 x-ui
+  ${green}10.${plain} 停止 x-ui
+  ${green}11.${plain} 重启 x-ui
+  ${green}12.${plain} 查看 x-ui 状态
+  ${green}13.${plain} 查看 x-ui 日志
 ————————————————
-  ${green}13.${plain} 设置 x-ui 开机自启
-  ${green}14.${plain} 取消 x-ui 开机自启
+  ${green}14.${plain} 设置 x-ui 开机自启
+  ${green}15.${plain} 取消 x-ui 开机自启
 ————————————————
-  ${green}15.${plain} 一键安装 bbr (最新内核)
-  ${green}16.${plain} 一键申请SSL证书(acme申请)
+  ${green}16.${plain} 一键安装 bbr (最新内核)
+  ${green}17.${plain} 一键申请SSL证书(acme申请)
  "
     show_status
-    echo && read -p "请输入选择 [0-16]: " num
+    echo && read -p "请输入选择 [0-17]: " num
 
     case "${num}" in
     0)
@@ -550,40 +563,43 @@ show_menu() {
         check_install && reset_config
         ;;
     6)
-        check_install && set_port
+        check_install && set_listen
         ;;
     7)
-        check_install && check_config
+        check_install && set_port
         ;;
     8)
-        check_install && start
+        check_install && check_config
         ;;
     9)
-        check_install && stop
+        check_install && start
         ;;
     10)
-        check_install && restart
+        check_install && stop
         ;;
     11)
-        check_install && status
+        check_install && restart
         ;;
     12)
-        check_install && show_log
+        check_install && status
         ;;
     13)
-        check_install && enable
+        check_install && show_log
         ;;
     14)
-        check_install && disable
+        check_install && enable
         ;;
     15)
-        install_bbr
+        check_install && disable
         ;;
     16)
+        install_bbr
+        ;;
+    17)
         ssl_cert_issue
         ;;
     *)
-        LOGE "请输入正确的数字 [0-16]"
+        LOGE "请输入正确的数字 [0-17]"
         ;;
     esac
 }


### PR DESCRIPTION
1. Support modifying the listening address after installation. For instance, modify it to 127.0.0.1 in order to use reverse proxy like Nginx in the upsream)
2. Print current listening address when printing panel status.